### PR TITLE
Fixed: Messages w/ attachments now send

### DIFF
--- a/templates/slack/_files/slack/utils/message.js
+++ b/templates/slack/_files/slack/utils/message.js
@@ -28,7 +28,7 @@ module.exports = (token, channel, text, callback) => {
 
   request.post({
     uri: 'https://slack.com/api/chat.postMessage',
-    form: formatMessage(token, channel, text)
+    form: data
   }, (err, result) => {
 
     if (err) {


### PR DESCRIPTION
Messages with `attachments` field failed to send before this fix.